### PR TITLE
feat: add SvelteKit to backend frameworks

### DIFF
--- a/data/groups.json
+++ b/data/groups.json
@@ -25,6 +25,7 @@
     "rails/rails",
     "spring-projects/spring-framework",
     "symfony/symfony",
+    "sveltejs/kit",
     "vercel/next.js"
   ],
   "text-editors": [


### PR DESCRIPTION
Although still in [beta](https://github.com/sveltejs/kit#read-this-first), SvelteKit is growing rapidly and has already gained 4.1k stars ⭐, being only public since the end of March 2021.

Ref: https://svelte.dev/blog/sveltekit-beta

I understand if there is some sort of requirement for this to be merged, (maybe waiting until it is out of beta), I just thought it just fits neatly in that category.

What do you think?